### PR TITLE
Question aboy encoding

### DIFF
--- a/bliki-core/src/main/resources/Messages_pl.properties
+++ b/bliki-core/src/main/resources/Messages_pl.properties
@@ -19,13 +19,13 @@ wiki.api.special1       = Specialne
 wiki.api.talk1          = Talk
 wiki.api.template1      = Template
 wiki.api.templatetalk1  = Template_talk
-wiki.api.user1          = Użytkownik
-wiki.api.usertalk1      = Użytkownik_dyskusja
-wiki.api.module1        = Moduł
-wiki.api.moduletalk1    = Moduł_dyskusja
+wiki.api.user1          = U\u017cytkownik
+wiki.api.usertalk1      = U\u017cytkownik_dyskusja
+wiki.api.module1        = Modu\u0142
+wiki.api.moduletalk1    = Modu\u0142_dyskusja
 
 wiki.api.url            = http://pl.wikipedia.org/w/api.php
-wiki.tags.toc.content   = Spis treści
+wiki.tags.toc.content   = Spis tre\u015bci
 wiki.tags.red-link = ${title} (strona nie istnieje)
 
 # based on English and my understanding German for clarification, I'm veryfying few Polish words

--- a/bliki-core/src/main/resources/Messages_pl.properties
+++ b/bliki-core/src/main/resources/Messages_pl.properties
@@ -28,4 +28,4 @@ wiki.api.url            = http://pl.wikipedia.org/w/api.php
 wiki.tags.toc.content   = Spis treści
 wiki.tags.red-link = ${title} (strona nie istnieje)
 
-# based on English and German clarification, I'm veryfying few Polish words
+# based on English and my understanding German for clarification, I'm veryfying few Polish words

--- a/bliki-core/src/main/resources/Messages_pl.properties
+++ b/bliki-core/src/main/resources/Messages_pl.properties
@@ -1,0 +1,31 @@
+wiki.api.category1      = Kategoria
+wiki.api.categorytalk1  = Kategoria_dyskusja
+wiki.api.help1          = Pomoc
+wiki.api.helptalk1      = Pomoc_dyskusja
+wiki.api.image1         = Plik
+wiki.api.image2         = Obraz
+wiki.api.imagetalk1     = Plik_dyskusja
+wiki.api.imagetalk2     = Obraz_dyskusja
+wiki.api.media1         = Media
+wiki.api.mediawiki1     = MediaWiki
+wiki.api.mediawikitalk1 = MediaWiki_talk
+wiki.api.meta1          = Projekt
+wiki.api.meta2          = Meta
+wiki.api.metatalk1      = Projekt_dyskusja
+wiki.api.metatalk2      = Meta_talk
+wiki.api.portal1        = Portal
+wiki.api.portaltalk1    = Portal_talk
+wiki.api.special1       = Specialne
+wiki.api.talk1          = Talk
+wiki.api.template1      = Template
+wiki.api.templatetalk1  = Template_talk
+wiki.api.user1          = Użytkownik
+wiki.api.usertalk1      = Użytkownik_dyskusja
+wiki.api.module1        = Moduł
+wiki.api.moduletalk1    = Moduł_dyskusja
+
+wiki.api.url            = http://pl.wikipedia.org/w/api.php
+wiki.tags.toc.content   = Spis treści
+wiki.tags.red-link = ${title} (strona nie istnieje)
+
+# based on English and German clarification, I'm veryfying few Polish words


### PR DESCRIPTION
Hi! This is in reality not (only) pull, but question:

Default for properties API is encoding ISO-8859-1
I see all (most) of existing Mesages_*.poperties files fit into this encoding
But Polish alphabet is outside of this standard (many alphabets too)

Let me know voice of community, is possible switch to UTF-8 properties encoding?
Such encoding is legal since Java 6 (if I remember).
This translation looks good (has correct polish characters) on my polish windows, but I dont know, how on others. 
Information: Microsoft codepage for PL is 1250, official standard from DOS-times ISO-8859-2

If someone accept early version of my translation for new file Messages_pl.poperties, can be pull'ed. 

Sorry, I'm not green developer, but new in github conventions and procedures.

