### PR TITLE
Fix WikipediaScanner#wpTable() : skip parsing raw HTML tags

### DIFF
--- a/bliki-core/src/main/java/info/bliki/wiki/filter/WikipediaScanner.java
+++ b/bliki-core/src/main/java/info/bliki/wiki/filter/WikipediaScanner.java
@@ -80,6 +80,21 @@ public class WikipediaScanner {
 
             while (true) {
                 ch = fSource[fScannerPosition++];
+
+                // If any HTML tag is detected, preserves it and skips.
+                // (HTML comments don't need to be considered because they are removed in advance.)
+                if (ch == '<') {
+                    WikiTagNode tag = parseTag(fScannerPosition);
+                    if (tag != null) {
+                        if (cell == null) {
+                            cell = new WPCell(tag.getTagBegin() - 1);
+                            cell.setType(WPCell.UNDEFINED);
+                            cells.add(cell);
+                        }
+                        continue;
+                    }
+                }
+
                 switch (ch) {
                 case '[':
                     int position = findNestedEndSingle(fSource, '[', ']', fScannerPosition);

--- a/bliki-core/src/test/java/info/bliki/wiki/filter/WPTableFilterTest.java
+++ b/bliki-core/src/test/java/info/bliki/wiki/filter/WPTableFilterTest.java
@@ -415,4 +415,16 @@ public class WPTableFilterTest extends FilterTestSupport {
                 "";
         assertThat(wikiModel.render(raw, false)).isEqualTo(expected);
     }
+
+    @Test public void testSkipHtmlTagInCell() throws Exception {
+        // the simplified output of Wiktionary's ru-verb module.
+        String targetHtmlTag = "<span class=\"... pres|act|part-form-of ...\">";
+        String raw ="{|\n" +
+                "|-\n" +
+                "| " + targetHtmlTag + " ... SOMETHING_TEXT\n" +
+                "|}\n";
+
+        String actual = wikiModel.render(raw, false);
+        assertThat(actual).contains(targetHtmlTag); // must be preserve the HTML tag.
+    }
 }


### PR DESCRIPTION
Hi axkr. This PR aims to process recent en-Wiktionary data well. (Jan. 1, 2021 dump, especially "ru-verb" module)

### Issue

Given the below MW table description:

```html
| <span class="Cyrl form-of lang-ru pres|act|part-form-of origin-чита́ть" lang="ru"> SOMETHING_TEXT
```

WikiModel#render() returns the below HTML:

```html
<td>act|part-form-of    origin-чита́ть   &#34; lang=&#34;ru&#34;&#62; SOMETHING_TEXT
```

### Cause

WikipediaScanner#wpTable() parses "|" (vertical bar) in the class attribute of the raw HTML tag. And wpTable() splits the tag incorrectly.

wpTable() should skip parsing raw HTML tags and preseve them.