### PR TITLE
Fix WikipediaScanner#wpTable() : recognize only "!" line as a empty TH tag.

### DIFF
--- a/bliki-core/src/main/java/info/bliki/wiki/filter/WikipediaScanner.java
+++ b/bliki-core/src/main/java/info/bliki/wiki/filter/WikipediaScanner.java
@@ -154,6 +154,11 @@ public class WikipediaScanner {
                         cell.setType(WPCell.TH);
                         cells.add(cell);
 
+                        // If the next character is "\n", the parser should restart at "\n".
+                        if (ch == '\n') {
+                            fScannerPosition--;
+                        }
+
                         break;
                     case '{': // "\n {"
                         if (fSource[fScannerPosition] == '|') {

--- a/bliki-core/src/test/java/info/bliki/wiki/filter/WPTableFilterTest.java
+++ b/bliki-core/src/test/java/info/bliki/wiki/filter/WPTableFilterTest.java
@@ -415,4 +415,17 @@ public class WPTableFilterTest extends FilterTestSupport {
                 "";
         assertThat(wikiModel.render(raw, false)).isEqualTo(expected);
     }
+
+    @Test public void testPutEmptyHeaderCell() throws Exception {
+        String raw = "{|\n" +
+                "|-\n" +
+                "!\n" +
+                "! FOO\n" +
+                "! BAR\n" +
+                "|}";
+        String expected = "<tr>\n<th></th>\n<th>FOO</th>\n<th>BAR</th></tr>";
+
+        String actual = wikiModel.render(raw);
+        assertThat(actual).contains(expected);
+    }
 }


### PR DESCRIPTION
Hi axkr. This PR aims to process recent en-Wiktionary data well. (Jan. 1, 2021 dump, especially "ru-verb" module)

### Issue

Given the below MW table description:

```
|- class="rowgroup"
!
! [[настоящее время|present tense]]
! [[будущее время|future tense]]
|- ...
```

Note that the second line is only "!".
I expects to convert to `<tr> <th></th> <th>... present ...</th> <th> ... future ...</th> </tr>`.

But WikiModel#render() returns the below HTML:

```html
<tr class="rowgroup">
<th>
! <a href="https://en.wiktionary.org/wiki/%D0%9D%D0%B0%D1%81%D1%82%D0%BE%D1%8F%D1%89%D0%B5%D0%B5_%D0%B2%D1%80%D0%B5%D0%BC%D1%8F" title="Настоящее время">present tense</a></th>
<th><a href="https://en.wiktionary.org/wiki/%D0%91%D1%83%D0%B4%D1%83%D1%89%D0%B5%D0%B5_%D0%B2%D1%80%D0%B5%D0%BC%D1%8F" title="Будущее время">future tense</a></th></tr>
...
```
In short, `<tr> <th>! ... present ...</th> <th> ... future ... </th> </tr>` .

### Cause

At the end of the first line, WikipediaScanner#wpTable() recognizes the character sequences "\n", "!" as the beginning of a new <th> cell.
And then wpTable() skips the next character "\n" at the end of the second line. This skip behaviour should not be performed.