### PR TITLE
Fix ScribuntoLuaEngine#callParserFunction() : adds named arguments support

### DIFF
--- a/bliki-core/src/main/java/info/bliki/wiki/template/namedargs/AbstractNamedArgsTemplateFunction.java
+++ b/bliki-core/src/main/java/info/bliki/wiki/template/namedargs/AbstractNamedArgsTemplateFunction.java
@@ -1,0 +1,35 @@
+package info.bliki.wiki.template.namedargs;
+
+import info.bliki.wiki.model.IWikiModel;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * An abstract template parser function with named arguments.
+ */
+public abstract class AbstractNamedArgsTemplateFunction implements INamedArgsTemplateFunction {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public abstract String parseFunction(
+            NamedArgs parts, IWikiModel model, char[] src, int beginIndex, int endIndex, boolean isSubst)
+            throws IOException;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String parseFunction(
+            List<String> parts, IWikiModel model, char[] src, int beginIndex, int endIndex, boolean isSubst)
+            throws IOException {
+        throw new AssertionError("No implementation.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public abstract String getFunctionDoc();
+}

--- a/bliki-core/src/main/java/info/bliki/wiki/template/namedargs/INamedArgsTemplateFunction.java
+++ b/bliki-core/src/main/java/info/bliki/wiki/template/namedargs/INamedArgsTemplateFunction.java
@@ -1,0 +1,47 @@
+package info.bliki.wiki.template.namedargs;
+
+import info.bliki.wiki.model.IWikiModel;
+import info.bliki.wiki.template.ITemplateFunction;
+
+import java.io.IOException;
+
+/**
+ * Interface for a template parser function with named arguments.
+ * (i.e.
+ * <code>
+ *   return function (CSS_page)
+ *     return mw.getCurrentFrame():extensionTag{
+ * 	     name = "templatestyles", args = { src = CSS_page }
+ *     }
+ *   end
+ * </code> )
+ */
+public interface INamedArgsTemplateFunction extends ITemplateFunction {
+    /**
+     * Parse a template function with named arguments.
+     *
+     * The result is also a text string in Wikipedia syntax notation which will be
+     * parsed again (recursively) in the TemplateParser step.
+     *
+     * @param parts
+     *          the parser function arguments
+     * @param model
+     *          the wiki model
+     * @param src
+     *          the array of the current Wikipedia source text.
+     * @param beginIndex
+     *          the beginning index, inclusive.
+     * @param endIndex
+     *          the ending index, exclusive.
+     * @param isSubst
+     *          if <code>true</code> the template function was called from
+     *          <code>subst</code> or <code>safesubst</code> function and the arguments of
+     *          the function are typically not parsed recursively.
+     * @return the result string of this template function or <code>null</code> if
+     *         the parsing fails or isn't valid.
+     * @throws IOException
+     */
+    String parseFunction(
+            NamedArgs parts, IWikiModel model, char[] src, int beginIndex, int endIndex, boolean isSubst)
+            throws IOException;
+}

--- a/bliki-core/src/main/java/info/bliki/wiki/template/namedargs/NamedArgs.java
+++ b/bliki-core/src/main/java/info/bliki/wiki/template/namedargs/NamedArgs.java
@@ -1,0 +1,36 @@
+package info.bliki.wiki.template.namedargs;
+
+import org.luaj.vm2.LuaTable;
+
+/**
+ * LuaTable wrapper for named arguments passed by callParserFunction().
+ */
+public class NamedArgs {
+    private LuaTable luaTable;
+
+    /**
+     * Constructor.
+     * @param luaTable named arguments passed by callParserFunction().
+     */
+    public NamedArgs(LuaTable luaTable) {
+        this.luaTable = luaTable;
+    }
+
+    /**
+     * get a listed argument.
+     * @param key index.
+     * @return stringified value.
+     */
+    public String getString(int key) {
+        return this.luaTable.get(key).checkjstring();
+    }
+
+    /**
+     * get a named argument.
+     * @param key key.
+     * @return stringified value.
+     */
+    public String getString(String key) {
+        return this.luaTable.get(key).checkjstring();
+    }
+}

--- a/bliki-core/src/test/java/info/bliki/extensions/scribunto/engine/lua/CallParserFunctionIntegrationTest.java
+++ b/bliki-core/src/test/java/info/bliki/extensions/scribunto/engine/lua/CallParserFunctionIntegrationTest.java
@@ -1,0 +1,104 @@
+package info.bliki.extensions.scribunto.engine.lua;
+
+import info.bliki.annotations.IntegrationTest;
+import info.bliki.wiki.filter.WikiTestModel;
+import info.bliki.wiki.model.IWikiModel;
+import info.bliki.wiki.model.WikiModel;
+import info.bliki.wiki.template.AbstractTemplateFunction;
+import info.bliki.wiki.template.namedargs.AbstractNamedArgsTemplateFunction;
+import info.bliki.wiki.template.namedargs.NamedArgs;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * The integration test of ScribuntoLuaEngine#callParserFunction().
+ */
+@Category(IntegrationTest.class)
+public class CallParserFunctionIntegrationTest {
+
+    public static class NamedArgsTestFunction extends AbstractNamedArgsTemplateFunction {
+        @Override
+        public String parseFunction(NamedArgs parts, IWikiModel model, char[] src,
+                                    int beginIndex, int endIndex, boolean isSubst) throws IOException {
+            String result = "named:" + String.join(",", parts.getString(123), parts.getString("abc"));
+            return result;
+        }
+
+        @Override
+        public String getFunctionDoc() {
+            return null;
+        }
+    }
+
+    public static class ListedTestFunction extends AbstractTemplateFunction {
+        @Override
+        public String parseFunction(List<String> parts, IWikiModel model, char[] src,
+                                    int beginIndex, int endIndex, boolean isSubst) throws IOException {
+            String result = "listed:" + String.join(",", parts);
+            return result;
+        }
+
+        @Override
+        public String getFunctionDoc() {
+            return null;
+        }
+    }
+
+    private WikiModel wikiModel;
+
+    @Before
+    public void setUp() throws Exception {
+        wikiModel = new WikiTestModel(Locale.ENGLISH,
+                "http://www.bliki.info/wiki/${image}",
+                "http://www.bliki.info/wiki/${title}",
+                "wikitestModel");
+
+        wikiModel.addTemplateFunction("#tag:named-args", new NamedArgsTestFunction());
+        wikiModel.addTemplateFunction("#tag:listed-args", new ListedTestFunction());
+
+        wikiModel.setUp();
+    }
+
+    /**
+     * This test expects the below process flow;
+     * <code>
+     *      "{{named-args}}"
+     *     --> wikitestModel/templates/named-args
+     *     --> wikitestModel/modules/named-args-caller.lua
+     *     --> wikitestModel/modules/parser-function-caller.lua
+     *     --> ScribuntoLuaEngine#callParserFunction()
+     *     --> NamedArgsTestFunction#parseFunction(namedArgsObject)
+     * </code>
+     */
+    @Test
+    public void namedArgsTest() throws IOException {
+        String source = "{{named-args}}";
+        String expected = "named:zyx,987";
+        String actual = wikiModel.render(source);
+        assertThat(actual).contains(expected);
+    }
+
+    /**
+     * This test expects the below process flow;
+     * <code>
+     *     "{{named-args}}"
+     *     --> wikitestModel/templates/listed-args
+     *     --> wikitestModel/modules/listed-args-caller.lua
+     *     --> wikitestModel/modules/parser-function-caller.lua
+     *     --> ScribuntoLuaEngine#callParserFunction()
+     *     --> ListedArgsTestFunction#parseFunction(stringList)
+     * </code>
+     */
+    @Test
+    public void listedArgsTest() throws IOException {
+        String source = "{{listed-args}}";
+        String expected = "listed:,234,cde,345"; // note: args[0] is always ""
+        String actual = wikiModel.render(source);
+        assertThat(actual).contains(expected);
+    }
+}

--- a/bliki-core/src/test/resources/wikitestModel/modules/listed-args-caller.lua
+++ b/bliki-core/src/test/resources/wikitestModel/modules/listed-args-caller.lua
@@ -1,0 +1,6 @@
+-- This file is simplification of the situation that calling normal listed arguments.
+local export = {}
+function export.show(frame)
+    return require("Module:parser-function-caller")("listed-args", { 234, "cde", 345 })
+end
+return export

--- a/bliki-core/src/test/resources/wikitestModel/modules/named-args-caller.lua
+++ b/bliki-core/src/test/resources/wikitestModel/modules/named-args-caller.lua
@@ -1,0 +1,6 @@
+-- This file is simplification of the situation that "Module:ru-verb" calls "Module:TemplateStyles" with named arguments in enwiktionary.
+local export = {}
+function export.show(frame)
+    return require("Module:parser-function-caller")("named-args", { abc = 987, [123] = "zyx" })
+end
+return export

--- a/bliki-core/src/test/resources/wikitestModel/modules/normal-args.lua
+++ b/bliki-core/src/test/resources/wikitestModel/modules/normal-args.lua
@@ -1,0 +1,7 @@
+local export = {}
+function export.show(frame)
+    return mw.getCurrentFrame():extensionTag{
+        name = "normal", args = { "cde", 234, "vwx" }
+    }
+end
+return export

--- a/bliki-core/src/test/resources/wikitestModel/modules/parser-function-caller.lua
+++ b/bliki-core/src/test/resources/wikitestModel/modules/parser-function-caller.lua
@@ -1,0 +1,6 @@
+-- This file is simplification of enwiktionary's "Module:TemplateStyles".
+return function (fn_name, fn_args)
+    return mw.getCurrentFrame():extensionTag{
+        name = fn_name, args = fn_args
+    }
+end

--- a/bliki-core/src/test/resources/wikitestModel/templates/listed-args
+++ b/bliki-core/src/test/resources/wikitestModel/templates/listed-args
@@ -1,0 +1,1 @@
+{{#invoke:listed-args-caller|show}}

--- a/bliki-core/src/test/resources/wikitestModel/templates/named-args
+++ b/bliki-core/src/test/resources/wikitestModel/templates/named-args
@@ -1,0 +1,1 @@
+{{#invoke:named-args-caller|show}}


### PR DESCRIPTION
Hi axkr. This PR aims to process recent en-Wiktionary data well. (Jan. 1, 2021 dump, especially "ru-verb" module)

### Issue

I'm trying to port "TemplateStyles" module. The all content of this module is below:

```lua
return function (CSS_page)
	return mw.getCurrentFrame():extensionTag{
		name = "templatestyles", args = { src = CSS_page }
	}
end
```

Note that "args" is a hash, not an array.  The example of usage of this module is below:

```lua
return require("Module:TemplateStyles")("Module:ru-verb/style.css") .. LONG_LONG_TEXT
```
I tried to implement "#tag:templateStyles" function by ITemplateFunction, but the hash  `args = { src = "Module:ru-verb/style.css" }` cannot be passed.

```java
configuration.addTemplateFunction("#tag:templateStyles", new ITemplateFunction() {
  @Override
  public String parseFunction(List<String> parts, IWikiModel model, char[] src, int beginIndex, int endIndex, boolean isSubst) throws IOException {
    // The value "Module:ru-verb/style.css" is not included in "parts".
    return "";
  }

  @Override
  public String getFunctionDoc() { return ""; }
});
```

### Cause

ScribuntoLuaEngine#callParserFunction() receives LuaTable "args". LuaTable's possible key types are integer, string and so on.
callParserFunction() reads only integer key entries and passes them to the ITemplateFunction imeplementation.

### Remarks

LuaTable supports a variety of key and value types. (bool, function, table, and so on) Supporting all Lua types is hard work and I don't want to do.
Therefore, this proposal introduces the LuaTable wrapper "NamedArgs". Currently, "NamedArgs" only supports integer and string keys. And all the values are converted to strings.

In addition, this proposal has not touched other existing codes invoking ITemplateFunction#parseFunction(). 
(For example: https://github.com/axkr/info.bliki.wikipedia_parser/blob/master/bliki-core/src/main/java/info/bliki/wiki/filter/TemplateParser.java#L748 )