### PR TITLE
Add en-wiktionary's namespaces.

### DIFF
--- a/bliki-core/src/main/java/info/bliki/wiki/namespaces/INamespace.java
+++ b/bliki-core/src/main/java/info/bliki/wiki/namespaces/INamespace.java
@@ -13,6 +13,7 @@ import java.util.ResourceBundle;
  * @see <a href="https://www.mediawiki.org/wiki/Manual:Namespace#Built-in_namespaces">Mediawiki - Manual:Namespace</a>
  * @see <a href="https://www.mediawiki.org/wiki/Extension_default_namespaces">Extension default namespaces</a>
  * @see <a href="https://github.com/wikimedia/mediawiki-core/blob/master/includes/Defines.php">Defines.php</a>
+ * @see <a href="https://en.wiktionary.org/wiki/Wiktionary:Namespace">Wiktionary namespaces</a>
  *
  */
 public interface INamespace {
@@ -108,6 +109,24 @@ public interface INamespace {
         CATEGORY_TALK_NAMESPACE_KEY(15),
 
         /**
+         * Wiktionary's "Thread".
+         */
+        THREAD_NAMESPACE_KEY(90),
+        /**
+         * Wiktionary's "Thread talk".
+         */
+        THREAD_TALK_NAMESPACE_KEY(91),
+
+        /**
+         * Wiktionary's "Summary".
+         */
+        SUMMARY_NAMESPACE_KEY(92),
+        /**
+         * Wiktionary's "Summary talk".
+         */
+        SUMMARY_TALK_NAMESPACE_KEY(93),
+
+        /**
          * Portal pages.
          */
         PORTAL_NAMESPACE_KEY(100),
@@ -117,8 +136,44 @@ public interface INamespace {
          */
         PORTAL_TALK_NAMESPACE_KEY(101),
 
+        /**
+         * Wiktionary's "Concordance".
+         */
+        CONCORDANCE_NAMESPACE_KEY(102),
+        CONCORDANCE_TALK_NAMESPACE_KEY(103),
+
+        /**
+         * Wiktionary's "Index".
+         */
+        INDEX_NAMESPACE_KEY(104),
+        INDEX_TALK_NAMESPACE_KEY(105),
+
+        /**
+         * Wiktionary's "Rhymes".
+         */
+        RHYMES_NAMESPACE_KEY(106),
+        RHYMES_TALK_NAMESPACE_KEY(107),
+
         BOOK_NAMESPACE_KEY(108),
         BOOK_TALK_NAMESPACE_KEY(109),
+
+        /**
+         * Wiktionary's "Thesaurus".
+         */
+        THESAURUS_NAMESPACE_KEY(110),
+        THESAURUS_TALK_NAMESPACE_KEY(111),
+
+        /**
+         * Wiktionary's "Citations".
+         */
+        CITATIONS_NAMESPACE_KEY(114),
+        CITATIONS_TALK_NAMESPACE_KEY(115),
+
+        /**
+         * Wiktionary's "Sign gloss".
+         */
+        SIGN_GLOSS_NAMESPACE_KEY(116),
+        SIGN_GLOSS_TALK_NAMESPACE_KEY(117),
 
         DRAFT_NAMESPACE_KEY(118),
         DRAFT_TALK_NAMESPACE_KEY(119),

--- a/bliki-core/src/main/java/info/bliki/wiki/namespaces/Namespace.java
+++ b/bliki-core/src/main/java/info/bliki/wiki/namespaces/Namespace.java
@@ -54,11 +54,11 @@ public class Namespace implements INamespace {
     /**
      * The "Meta talk" namespace for the current language.
      */
-    public final NamespaceValue PROJECT_TALK = new NamespaceValue(PROJECT_TALK_NAMESPACE_KEY, "Project_talk", "Meta_talk");
+    public final NamespaceValue PROJECT_TALK = new NamespaceValue(PROJECT_TALK_NAMESPACE_KEY, "Project_talk", "Meta_talk", "Wiktionary_talk");
     /**
      * The "Meta" namespace for the current language.
      */
-    public final NamespaceValue PROJECT = new NamespaceValue(PROJECT_NAMESPACE_KEY, PROJECT_TALK, "Project", "Meta");
+    public final NamespaceValue PROJECT = new NamespaceValue(PROJECT_NAMESPACE_KEY, PROJECT_TALK, "Project", "Meta", "Wiktionary");
 
     /**
      * NS_IMAGE and NS_IMAGE_TALK are the pre-v1.14 names for NS_FILE and
@@ -83,7 +83,7 @@ public class Namespace implements INamespace {
     /**
      * The "Module" namespace for the current language.
      */
-    public final NamespaceValue MODULE = new NamespaceValue(MODULE_NAMESPACE_KEY, MODULE_TALK, "Module");
+    public final NamespaceValue MODULE = new NamespaceValue(MODULE_NAMESPACE_KEY, MODULE_TALK, "Module", "MOD");
     /**
      * The "Template talk" namespace for the current language.
      */
@@ -91,7 +91,7 @@ public class Namespace implements INamespace {
     /**
      * The "Template" namespace for the current language.
      */
-    public final NamespaceValue TEMPLATE = new NamespaceValue(TEMPLATE_NAMESPACE_KEY, TEMPLATE_TALK, "Template");
+    public final NamespaceValue TEMPLATE = new NamespaceValue(TEMPLATE_NAMESPACE_KEY, TEMPLATE_TALK, "Template", "T");
 
     /**
      * The "Help talk" namespace for the current language.
@@ -108,21 +108,21 @@ public class Namespace implements INamespace {
     /**
      * The "Category" namespace for the current language.
      */
-    public final NamespaceValue CATEGORY = new NamespaceValue(CATEGORY_NAMESPACE_KEY, CATEGORY_TALK, "Category");
+    public final NamespaceValue CATEGORY = new NamespaceValue(CATEGORY_NAMESPACE_KEY, CATEGORY_TALK, "Category", "CAT");
     /**
      * The "Portal talk" namespace for the current language.
      */
-    public final NamespaceValue PORTAL_TALK = new NamespaceValue(PORTAL_TALK_NAMESPACE_KEY, "Portal_talk");
+    public final NamespaceValue PORTAL_TALK = new NamespaceValue(PORTAL_TALK_NAMESPACE_KEY, "Portal_talk", "Appendix_talk");
     /**
      * The "Portal" namespace for the current language.
      */
-    public final NamespaceValue PORTAL = new NamespaceValue(PORTAL_NAMESPACE_KEY, PORTAL_TALK, "Portal");
+    public final NamespaceValue PORTAL = new NamespaceValue(PORTAL_NAMESPACE_KEY, PORTAL_TALK, "Portal", "Appendix", "AP");
 
-    public final NamespaceValue BOOK_TALK = new NamespaceValue(BOOK_TALK_NAMESPACE_KEY, "Book_talk");
-    public final NamespaceValue BOOK = new NamespaceValue(BOOK_NAMESPACE_KEY, BOOK_TALK, "Book");
+    public final NamespaceValue BOOK_TALK = new NamespaceValue(BOOK_TALK_NAMESPACE_KEY, "Book_talk", "Transwiki_talk");
+    public final NamespaceValue BOOK = new NamespaceValue(BOOK_NAMESPACE_KEY, BOOK_TALK, "Book", "Transwiki");
 
-    public final NamespaceValue DRAFT_TALK = new NamespaceValue(DRAFT_TALK_NAMESPACE_KEY, "Draft_talk");
-    public final NamespaceValue DRAFT = new NamespaceValue(DRAFT_NAMESPACE_KEY, DRAFT_TALK, "Draft");
+    public final NamespaceValue DRAFT_TALK = new NamespaceValue(DRAFT_TALK_NAMESPACE_KEY, "Draft_talk", "Reconstruction_talk");
+    public final NamespaceValue DRAFT = new NamespaceValue(DRAFT_NAMESPACE_KEY, DRAFT_TALK, "Draft", "Reconstruction", "RC");
 
     public final NamespaceValue EP_TALK = new NamespaceValue(EP_TALK_NAMESPACE_KEY, "Education_Program_talk");
     public final NamespaceValue EP = new NamespaceValue(EP_NAMESPACE_KEY, EP_TALK, "Education_Program");
@@ -131,6 +131,30 @@ public class Namespace implements INamespace {
     public final NamespaceValue TIMEDTEXT = new NamespaceValue(TIMEDTEXT_NAMESPACE_KEY, TIMEDTEXT_TALK, "TimedText");
 
     public final NamespaceValue TOPIC = new NamespaceValue(TOPIC_NAMESPACE_KEY, "Topic");
+
+    public final NamespaceValue THREAD_TALK = new NamespaceValue(THREAD_TALK_NAMESPACE_KEY, "Thread_talk");
+    public final NamespaceValue THREAD = new NamespaceValue(THREAD_NAMESPACE_KEY, THREAD_TALK, "Thread");
+
+    public final NamespaceValue SUMMARY_TALK = new NamespaceValue(SUMMARY_TALK_NAMESPACE_KEY, "Summary_talk");
+    public final NamespaceValue SUMMARY = new NamespaceValue(SUMMARY_NAMESPACE_KEY, SUMMARY_TALK, "Summary");
+
+    public final NamespaceValue CONCORDANCE_TALK = new NamespaceValue(CONCORDANCE_TALK_NAMESPACE_KEY, "Concordance_talk");
+    public final NamespaceValue CONCORDANCE = new NamespaceValue(CONCORDANCE_NAMESPACE_KEY, CONCORDANCE_TALK, "Concordance");
+
+    public final NamespaceValue INDEX_TALK = new NamespaceValue(INDEX_TALK_NAMESPACE_KEY, "Index_talk");
+    public final NamespaceValue INDEX = new NamespaceValue(INDEX_NAMESPACE_KEY, INDEX_TALK, "Index");
+
+    public final NamespaceValue RHYMES_TALK = new NamespaceValue(RHYMES_TALK_NAMESPACE_KEY, "Rhymes_talk");
+    public final NamespaceValue RHYMES = new NamespaceValue(RHYMES_NAMESPACE_KEY, RHYMES_TALK, "Rhymes");
+
+    public final NamespaceValue THESAURUS_TALK = new NamespaceValue(THESAURUS_TALK_NAMESPACE_KEY, "Thesaurus_talk", "Wikisaurus talk");
+    public final NamespaceValue THESAURUS = new NamespaceValue(THESAURUS_NAMESPACE_KEY, THESAURUS_TALK, "Thesaurus", "Wikisaurus", "WS");
+
+    public final NamespaceValue CITATIONS_TALK = new NamespaceValue(CITATIONS_TALK_NAMESPACE_KEY, "Citations_talk");
+    public final NamespaceValue CITATIONS = new NamespaceValue(CITATIONS_NAMESPACE_KEY, CITATIONS_TALK, "Citations");
+
+    public final NamespaceValue SIGN_GLOSS_TALK = new NamespaceValue(SIGN_GLOSS_TALK_NAMESPACE_KEY, "Sign_gloss_talk");
+    public final NamespaceValue SIGN_GLOSS = new NamespaceValue(SIGN_GLOSS_NAMESPACE_KEY, SIGN_GLOSS_TALK, "Sign_gloss");
 
     protected ResourceBundle fResourceBundle, fResourceBundleEn;
 
@@ -247,6 +271,18 @@ public class Namespace implements INamespace {
         // already in the English resource bundle:
         // IMAGE.addAlias("Image");
         // IMAGE_TALK.addAlias("Image_talk");
+
+        // Re-adds Wiktionary's aliases.
+        // Note: Wiktionary's "WT" alias (related to "PROJECT" namespace) is not implemented.
+        PORTAL.addAlias("AP");
+        PORTAL.addAlias("Appendix");
+        PORTAL_TALK.addAlias("Appendix_talk");
+        CATEGORY.addAlias("CAT");
+        MODULE.addAlias("MOD");
+        DRAFT.addAlias("RC");
+        TEMPLATE.addAlias("T");
+        PROJECT.addAlias("Wiktionary");
+        PROJECT_TALK.addAlias("Wiktionary_talk");
     }
 
     @Override

--- a/bliki-core/src/test/java/info/bliki/wiki/namespaces/NamespaceIntegrationTest.java
+++ b/bliki-core/src/test/java/info/bliki/wiki/namespaces/NamespaceIntegrationTest.java
@@ -1,0 +1,42 @@
+package info.bliki.wiki.namespaces;
+
+import info.bliki.annotations.IntegrationTest;
+import info.bliki.extensions.scribunto.template.Frame;
+import info.bliki.wiki.filter.WikiTestModel;
+import info.bliki.wiki.model.WikiModel;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Category(IntegrationTest.class)
+public class NamespaceIntegrationTest {
+
+    private WikiModel wikiModel;
+
+    @Before
+    public void setUp() throws Exception {
+        wikiModel = new WikiTestModel(Locale.ENGLISH,
+                "http://www.bliki.info/wiki/${image}",
+                "http://www.bliki.info/wiki/${title}",
+                "wikitestModel");
+        wikiModel.setUp();
+    }
+
+    @Test
+    public void mwTitleInNamespaceTest() throws IOException {
+        // This test aims to guarantee that enwiktionary's headword#non_categorizable() function doesn't throw error.
+
+        String[] testNamespaces = {"", "Appendix"};
+        for (String ns : testNamespaces) {
+            wikiModel.setFrame(new Frame(null, null, null, false));
+            String source = "{{#invoke:mw-title-in-namespace|inNamespaceTest|" + ns + "}}";
+            String result = wikiModel.parseTemplates(source);
+            assertThat(result).isNotEmpty();
+        }
+    }
+}

--- a/bliki-core/src/test/java/info/bliki/wiki/namespaces/NamespaceTest.java
+++ b/bliki-core/src/test/java/info/bliki/wiki/namespaces/NamespaceTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 
 import java.util.Locale;
 
+import static info.bliki.wiki.namespaces.INamespace.NamespaceCode.*;
+import static info.bliki.wiki.namespaces.INamespace.NamespaceCode.CITATIONS_NAMESPACE_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -42,6 +44,10 @@ public class NamespaceTest {
         assertThat(namespace.getNamespace("Project")).isEqualTo(namespace.PROJECT);
         assertThat(namespace.getNamespace("Project_talk")).isEqualTo(namespace.PROJECT_TALK);
         assertThat(namespace.getNamespace("Project talk")).isEqualTo(namespace.PROJECT_TALK);
+        assertThat(namespace.getNamespace("Wiktionary")).isEqualTo(namespace.PROJECT);
+        assertThat(namespace.getNamespace("Wiktionary_talk")).isEqualTo(namespace.PROJECT_TALK);
+        assertThat(namespace.getNamespace("Wiktionary talk")).isEqualTo(namespace.PROJECT_TALK);
+        assertThat(namespace.getNamespace("WT")).isEqualTo(namespace.PROJECT_TALK);
     }
 
     @Test public void testTalkspace001() {
@@ -51,6 +57,10 @@ public class NamespaceTest {
         assertThat(namespace.getTalkspace("Project")).isEqualTo(namespace.PROJECT_TALK);
         assertThat(namespace.getTalkspace("Project_talk")).isEqualTo(namespace.PROJECT_TALK);
         assertThat(namespace.getTalkspace("Project talk")).isEqualTo(namespace.PROJECT_TALK);
+        assertThat(namespace.getTalkspace("Wiktionary")).isEqualTo(namespace.PROJECT_TALK);
+        assertThat(namespace.getTalkspace("Wiktionary_talk")).isEqualTo(namespace.PROJECT_TALK);
+        assertThat(namespace.getTalkspace("Wiktionary talk")).isEqualTo(namespace.PROJECT_TALK);
+        assertThat(namespace.getTalkspace("WT")).isEqualTo(namespace.PROJECT_TALK);
     }
 
     @Test public void testContentspace001() {
@@ -60,6 +70,10 @@ public class NamespaceTest {
         assertThat(namespace.getContentspace("Project")).isEqualTo(namespace.PROJECT);
         assertThat(namespace.getContentspace("Project_talk")).isEqualTo(namespace.PROJECT);
         assertThat(namespace.getContentspace("Project talk")).isEqualTo(namespace.PROJECT);
+        assertThat(namespace.getContentspace("Wiktionary")).isEqualTo(namespace.PROJECT);
+        assertThat(namespace.getContentspace("Wiktionary_talk")).isEqualTo(namespace.PROJECT);
+        assertThat(namespace.getContentspace("Wiktionary talk")).isEqualTo(namespace.PROJECT);
+        assertThat(namespace.getContentspace("WT")).isEqualTo(namespace.PROJECT);
     }
 
     @Test public void testOldAliases001() {
@@ -68,22 +82,47 @@ public class NamespaceTest {
         assertThat(namespace.getNamespace("Category_talk")).isEqualTo(null);
     }
 
+    @Test public void testCategoryNamespace() {
+        assertThat(namespace.getNamespace("Category")).isEqualTo(namespace.CATEGORY);
+        assertThat(namespace.getContentspace("Category_talk")).isEqualTo(namespace.CATEGORY);
+        assertThat(namespace.getNamespace("Category talk")).isEqualTo(namespace.CATEGORY_TALK);
+        assertThat(namespace.getNamespace("CAT")).isEqualTo(namespace.CATEGORY);
+    }
+
     @Test public void testModuleNamespace() {
         assertThat(namespace.getNamespace("Module")).isEqualTo(namespace.MODULE);
         assertThat(namespace.getContentspace("Module_talk")).isEqualTo(namespace.MODULE);
         assertThat(namespace.getNamespace("Module_talk")).isEqualTo(namespace.MODULE_TALK);
+        assertThat(namespace.getNamespace("MOD")).isEqualTo(namespace.MODULE);
+    }
+
+    @Test public void testPortalNamespace() {
+        assertThat(namespace.getNamespace("Portal")).isEqualTo(namespace.PORTAL);
+        assertThat(namespace.getContentspace("Portal_talk")).isEqualTo(namespace.PORTAL);
+        assertThat(namespace.getNamespace("Portal_talk")).isEqualTo(namespace.PORTAL_TALK);
+        assertThat(namespace.getNamespace("Appendix")).isEqualTo(namespace.PORTAL);
+        assertThat(namespace.getContentspace("Appendix_talk")).isEqualTo(namespace.PORTAL);
+        assertThat(namespace.getNamespace("Appendix_talk")).isEqualTo(namespace.PORTAL_TALK);
+        assertThat(namespace.getNamespace("AP")).isEqualTo(namespace.PORTAL);
     }
 
     @Test public void testBookNamespace() {
         assertThat(namespace.getNamespace("Book")).isEqualTo(namespace.BOOK);
         assertThat(namespace.getContentspace("Book_talk")).isEqualTo(namespace.BOOK);
         assertThat(namespace.getNamespace("Book_talk")).isEqualTo(namespace.BOOK_TALK);
+        assertThat(namespace.getNamespace("Transwiki")).isEqualTo(namespace.BOOK);
+        assertThat(namespace.getContentspace("Transwiki_talk")).isEqualTo(namespace.BOOK);
+        assertThat(namespace.getNamespace("Transwiki_talk")).isEqualTo(namespace.BOOK_TALK);
     }
 
     @Test public void testDraftNamespace() {
         assertThat(namespace.getNamespace("Draft")).isEqualTo(namespace.DRAFT);
         assertThat(namespace.getContentspace("Draft_talk")).isEqualTo(namespace.DRAFT);
         assertThat(namespace.getNamespace("Draft_talk")).isEqualTo(namespace.DRAFT_TALK);
+        assertThat(namespace.getNamespace("Reconstruction")).isEqualTo(namespace.DRAFT);
+        assertThat(namespace.getContentspace("Reconstruction_talk")).isEqualTo(namespace.DRAFT);
+        assertThat(namespace.getNamespace("Reconstruction_talk")).isEqualTo(namespace.DRAFT_TALK);
+        assertThat(namespace.getNamespace("RC")).isEqualTo(namespace.DRAFT);
     }
 
     @Test public void testEducationProgramNamespace() {
@@ -106,5 +145,64 @@ public class NamespaceTest {
         assertThat(namespace.PROJECT_TALK.getCanonicalName()).isEqualTo("Project_talk");
         assertThat(new Namespace(Locale.GERMAN).PROJECT_TALK.getCanonicalName()).isEqualTo("Project_talk");
         assertThat(new Namespace(Locale.FRENCH).PROJECT_TALK.getCanonicalName()).isEqualTo("Project_talk");
+    }
+
+    @Test public void testTemplateNamespace() {
+        assertThat(namespace.getNamespace("Template")).isEqualTo(namespace.TEMPLATE);
+        assertThat(namespace.getContentspace("Template_talk")).isEqualTo(namespace.TEMPLATE);
+        assertThat(namespace.getNamespace("Template_talk")).isEqualTo(namespace.TEMPLATE_TALK);
+        assertThat(namespace.getContentspace("T")).isEqualTo(namespace.TEMPLATE);
+    }
+
+    @Test public void testThreadNamespace() {
+        assertThat(namespace.getNamespace("Thread")).isEqualTo(namespace.THREAD);
+        assertThat(namespace.getContentspace("Thread_talk")).isEqualTo(namespace.THREAD);
+        assertThat(namespace.getNamespace("Thread_talk")).isEqualTo(namespace.THREAD_TALK);
+    }
+
+    @Test public void testSummaryNamespace() {
+        assertThat(namespace.getNamespace("Summary")).isEqualTo(namespace.SUMMARY);
+        assertThat(namespace.getContentspace("Summary_talk")).isEqualTo(namespace.SUMMARY);
+        assertThat(namespace.getNamespace("Summary_talk")).isEqualTo(namespace.SUMMARY_TALK);
+    }
+
+    @Test public void testConcordanceNamespace() {
+        assertThat(namespace.getNamespace("Concordance")).isEqualTo(namespace.CONCORDANCE);
+        assertThat(namespace.getContentspace("Concordance_talk")).isEqualTo(namespace.CONCORDANCE);
+        assertThat(namespace.getNamespace("Concordance_talk")).isEqualTo(namespace.CONCORDANCE_TALK);
+    }
+
+    @Test public void testIndexNamespace() {
+        assertThat(namespace.getNamespace("Index")).isEqualTo(namespace.INDEX);
+        assertThat(namespace.getContentspace("Index_talk")).isEqualTo(namespace.INDEX);
+        assertThat(namespace.getNamespace("Index_talk")).isEqualTo(namespace.INDEX_TALK);
+    }
+
+    @Test public void testRhymesNamespace() {
+        assertThat(namespace.getNamespace("Rhymes")).isEqualTo(namespace.RHYMES);
+        assertThat(namespace.getContentspace("Rhymes_talk")).isEqualTo(namespace.RHYMES);
+        assertThat(namespace.getNamespace("Rhymes_talk")).isEqualTo(namespace.RHYMES_TALK);
+    }
+
+    @Test public void testThesaurusNamespace() {
+        assertThat(namespace.getNamespace("Thesaurus")).isEqualTo(namespace.THESAURUS);
+        assertThat(namespace.getContentspace("Thesaurus_talk")).isEqualTo(namespace.THESAURUS);
+        assertThat(namespace.getNamespace("Thesaurus_talk")).isEqualTo(namespace.THESAURUS_TALK);
+        assertThat(namespace.getNamespace("Wikisaurus")).isEqualTo(namespace.THESAURUS);
+        assertThat(namespace.getContentspace("Wikisaurus_talk")).isEqualTo(namespace.THESAURUS);
+        assertThat(namespace.getNamespace("Wikisaurus_talk")).isEqualTo(namespace.THESAURUS_TALK);
+        assertThat(namespace.getNamespace("WS")).isEqualTo(namespace.THESAURUS);
+    }
+
+    @Test public void testCitationsNamespace() {
+        assertThat(namespace.getNamespace("Citations")).isEqualTo(namespace.CITATIONS);
+        assertThat(namespace.getContentspace("Citations_talk")).isEqualTo(namespace.CITATIONS);
+        assertThat(namespace.getNamespace("Citations_talk")).isEqualTo(namespace.CITATIONS_TALK);
+    }
+
+    @Test public void testSignGlossNamespace() {
+        assertThat(namespace.getNamespace("Sign_gloss")).isEqualTo(namespace.SIGN_GLOSS);
+        assertThat(namespace.getContentspace("Sign_gloss_talk")).isEqualTo(namespace.SIGN_GLOSS);
+        assertThat(namespace.getNamespace("Sign_gloss_talk")).isEqualTo(namespace.SIGN_GLOSS_TALK);
     }
 }

--- a/bliki-core/src/test/resources/wikitestModel/modules/mw-title-in-namespace.lua
+++ b/bliki-core/src/test/resources/wikitestModel/modules/mw-title-in-namespace.lua
@@ -1,0 +1,11 @@
+local export = {}
+
+function export.inNamespaceTest(frame)
+    local ns = frame.args[1]
+    local title = mw.title.getCurrentTitle()
+    local result = title:inNamespace(ns)
+    local msg = "inNamespace(" .. ns .. ") with title = " .. tostring(title) .. " returns " .. tostring(result) .. "."
+    return msg
+end
+
+return export


### PR DESCRIPTION
Hi axkr. This PR aims to process recent en-Wiktionary data well. (Jan. 1, 2021 dump, especially "ru-verb" module)

### Issue

Given the below description with the en-Wiktionary's recent "ru-verb" template:
```
{{ru-conj|impf|1a+p|чита́ть}}
```

WikiModel#render() returns the below exception message:
```
01:28:37.169 [main] TRACE i.b.e.s.e.lua.ScribuntoLuaEngine - executing function: Module:ru-headword:126-235
01:28:37.183 [main] ERROR i.bliki.wiki.filter.TemplateParser - TemplateParserError
org.luaj.vm2.LuaError: @mw.title.lua:27 bad argument #1 to 'inNamespace' (unrecognized namespace name 'Appendix')
	at org.luaj.vm2.lib.BaseLib$error.call(Unknown Source)
	at org.luaj.vm2.LuaClosure.execute(Unknown Source)
... snip ...
	at org.luaj.vm2.LuaClosure.call(Unknown Source)
	at info.bliki.extensions.scribunto.engine.lua.ScribuntoLuaEngine.executeFunctionChunk(ScribuntoLuaEngine.java:142)
	at info.bliki.extensions.scribunto.engine.lua.ScribuntoLuaModule.invoke(ScribuntoLuaModule.java:32)
... snip ...
```

### Cause

The Luaj's stacktrace is below:
```
stack traceback:
	Module:headword:90: in function 'non_categorizable'
	Module:headword:629: in function 'full_headword'
	Module:ru-headword:233: in function 'chunk'
	mw.lua:511: in function <mw.lua:498>
	[Java]: in ?
```

The en-Wiktionary's recent "headword" module uses "Appendix" namespace. ( https://en.wiktionary.org/wiki/Module:headword#L-90 )

```lua
local function non_categorizable()
	return (title:inNamespace("") and title.text:find("^Unsupported titles/"))
		or (title:inNamespace("Appendix") and title.text:find("^Gestures/"))
end
```

It seems better to add all the Wiktionary-specific namespaces. https://en.wiktionary.org/wiki/Wiktionary:Namespace

### Remarks

Obviously, this PR is not scalable. In addition, this PR does not implement the en-Wiktionary "WT" alias because it conflicts with the en-Wikipedia "WT" alias.

So I tried to override IWikiModel#getNamespace() in order to replace the original "Namespace" class with an en-Wiktionary-specific Namespace class, but for now I'm giving up.
It is because there are many of direct references to the concrete classes "Namespace", "Namespace.NamespaceValue" and "INamespace.NamespaceCodes".
(An simple example: https://github.com/axkr/info.bliki.wikipedia_parser/blob/master/bliki-core/src/main/java/info/bliki/extensions/scribunto/engine/lua/interfaces/MwSite.java#L127 )

Ideally, all namespace definitions, including IDs, should be specified in the external configuration file.